### PR TITLE
Add CLAUDE.md with project architecture guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,9 +29,10 @@ The bot has three main layers:
 
 - **Thread = session**: one Discord thread ↔ one Claude Code process. Thread ID is the session key.
 - **Streaming via message editing**: bot sends an initial message then edits it as output accumulates; a ✅ reaction signals completion.
-- **Secret redaction**: all output must be filtered through configurable regex patterns before being sent to Discord (default patterns cover `sk-*`, `ghp_*`, `AKIA*`).
-- **Approval gates**: destructive file operations surface a Discord embed with ✅/❌ reactions before proceeding (configurable `autoApprove`).
+- **Secret redaction**: all output must be filtered through configurable regex patterns before being sent to Discord (default patterns: `sk-[a-zA-Z0-9]+`, `ghp_[a-zA-Z0-9]+`, `AKIA[A-Z0-9]+`).
+- **Approval gates**: destructive file operations surface a Discord embed with ✅/❌ reactions before proceeding (configurable `autoApprove`; file deletions always require approval).
 - **Command allowlist**: `/run` only executes commands in the project config's `allowedShellCommands` list.
+- **Audit log**: all commands and Claude Code invocations must be logged with user, timestamp, and working directory.
 
 ## Configuration shape
 
@@ -47,9 +48,9 @@ The bot has three main layers:
   "projects": {
     "<name>": {
       "path": "/abs/path/to/repo",
-      "commands": { "test": "...", "build": "...", "lint": "..." },
+      "commands": { "test": "...", "build": "...", "lint": "...", "typecheck": "npx tsc --noEmit" },
       "autoApprove": false,
-      "allowedShellCommands": ["npm", "npx", "node", "git", "cat", "ls"]
+      "allowedShellCommands": ["npm", "npx", "node", "git", "cat", "ls", "grep"]
     }
   }
 }


### PR DESCRIPTION
## Summary

- Creates `CLAUDE.md` to guide future Claude Code sessions in this repo
- Documents the planned tech stack (discord.js v14, node-pty, cosmiconfig, pino)
- Describes the three-layer architecture: Discord layer → Session manager → Process layer
- Captures key design constraints from the PRD (thread=session, streaming via message editing, secret redaction, approval gates)
- Includes the configuration schema and phased milestone breakdown

## Test plan

- [ ] Review that architecture description matches PRD.md accurately
- [ ] Confirm configuration schema is complete and correct
- [ ] Verify nothing contradicts the PRD open questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)