### PR TITLE
docs: add MIT LICENSE and INDEX.md

### DIFF
--- a/INDEX.md
+++ b/INDEX.md
@@ -1,0 +1,14 @@
+# claudebot — Document Index
+
+## Overview
+A Discord bot that gives you remote access to Claude Code CLI sessions from any device.
+
+## Documents
+
+| File | Description |
+|------|-------------|
+| [README.md](README.md) | User-facing documentation: setup, usage, configuration, commands |
+| [PRD.md](PRD.md) | Product Requirements Document — features, phases, design decisions |
+| [DESIGN.md](DESIGN.md) | Technical design: architecture, data flow, security model |
+| [PROCESS.md](PROCESS.md) | Development process: build approach, CI, contribution rules |
+| [CLAUDE.md](CLAUDE.md) | AI agent guidance: codebase context for Claude Code |

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 larkly
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
## Summary

- Adds MIT LICENSE file (project had no license file)
- Adds INDEX.md for document discoverability

🤖 Generated by autonomous work queue heartbeat