### PR TITLE
ci: add test step with jest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,18 @@ jobs:
       - name: Typecheck
         run: npm run typecheck
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run tests
+        run: npm test
+
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Adds a test job to the CI workflow that runs `npm test` (jest). Claudebot has jest configured in devDependencies and a `test` script in package.json, but the CI was only running typecheck and lint.